### PR TITLE
Fix escape_quotes() edge case

### DIFF
--- a/bin/shellmock
+++ b/bin/shellmock
@@ -70,7 +70,7 @@ shellmock_escape_special_chars()
 #-------------------------------------------------------------------
 shellmock_escape_quotes()
 {
-    $ECHO "$*" | $SED -e 's/"/\\"/g'
+    POSIXLY_CORRECT=1 $ECHO "$*" | $SED -e 's/"/\\"/g'
 }
 
 #------------------------------------

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -292,3 +292,15 @@ teardown()
     [ "${#capture[@]}" = "1" ]
     [ "${capture[0]}" = "cp-stub" ]
 }
+
+@test "shellmock_expect --match '--version'" {
+
+    skipIfNot match-version
+
+    shellmock_clean
+    shellmock_expect foo --match "--version" --output "Foo version"
+
+    run foo --version
+    [ "$status" = "0" ]
+    [ "$output" = "Foo version" ]
+}


### PR DESCRIPTION
There is an edge case when the quote escaping function does not work as
expected: When the parameters to be escaped match an argument of the
actual `echo` binary.

For example, when you try to escape '--version', it gets expanded to
"/bin/echo --version", which outputs the version of the echo utility
instead of the string '--version'.

This can be avoided by forcing `echo` to not parse any arguments via the
`POSIXLY_CORRECT` env variable.

This affects the `echo` version of the GNU coreutils package.

Reference point:
http://git.savannah.gnu.org/cgit/coreutils.git/tree/src/echo.c#n111