### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,6 @@ can be used to restrict testing to a single function and skipping all others.  I
 setup()
 {
     . shellmock
-    shellmock_clean
 }
 
 teardown()


### PR DESCRIPTION
Fixed typo, shellmock_clean is supposed to be called in teardown