### PR TITLE
Resolves Issue #24 - Improper handling of arguments with spaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/sample-bats/tmpstubs/
+.idea
+*.out
+*.err

--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,16 @@ teardown()
 
 ```
 
+== Environment Variables
+|===
+| Name | Purpose
+| TEST_FUNCTION | Bats variable the is used to control debugging i shellmock. When
+set to the name of a test case then all tmp and debug output is
+preserved.
+| SHELLMOCK_V1_COMPATIBILITY | v1.2 introduced logic that handles matching
+arguments differently when they contain spaces.  As a result old tests
+could fail to match.  This flag allows the old tests to continue to pass.
+|===
 
 == Adding Mocks in one of your tests
 

--- a/README.adoc
+++ b/README.adoc
@@ -231,6 +231,7 @@ run testscript.sh
 [ "$status" = "0" ]
 
 shellmock_verify
+[ "${capture[@]} = 1 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 
 ```
@@ -247,6 +248,7 @@ run testscript.sh
 [ "$status" = "1" ]
 
 shellmock_verify
+[ "${capture[@]} = 1 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 
 ```
@@ -263,8 +265,32 @@ run testscript.sh
 [ "$status" = "0" ]
 
 shellmock_verify
+[ "${capture[@]} = 2 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 [ "${capture[1]} = "grep-stub string1 file3" ]
+
+```
+
+===== Mock with whitespace in the parameters
+
+If the **grep** command is run by the script under test it will return a status 0 if arg1 is "string1" regardless of the rest of the args.  In order
+to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
+
+If the --match argument were "'string1 string2' file", where the double quotes and single quotes are
+swapped, then shellmock treats the string as if it were '"string1 string2" file'.  That will be evident in the
+capture array.  This is due to how the shell treats " and '.  Shellmock can not always tell the difference so we have
+normalized them to double quotes.
+
+```bash
+shellmock_expect grep --status 0 --type partial --match '"string1 string2" file'
+
+run testscript.sh
+[ "$status" = "0" ]
+
+shellmock_verify
+[ "${capture[@]} = 2 ]
+[ "${capture[0]} = 'grep-stub "string1 string2" file2' ]
+[ "${capture[1]} = 'grep-stub "string1 string2" file3' ]
 
 ```
 
@@ -303,7 +329,7 @@ run testscript.sh
 [ "${line[1]}" = "mycustom output2" ]
 
 shellmock_verify
-[ "${capture[0]} = "grep-stub string1 file1" ]
+[ "${capture[0]} = "grep-stub tag1 string1 file1" ]
 
 ```
 

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -277,8 +277,12 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
+    if [ "$MTYPE" != "X" ]; then
+        MATCH_NORM=`eval shellmock_normalize_args "$MATCH"`
+    else
+        MATCH_NORM=$MATCH
+    fi
 
-    MATCH_NORM=`shellmock_normalize_args $MATCH`
     shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
     if [ "$FORWARD" != "" ]; then
         $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
@@ -366,6 +370,8 @@ shellmock_replay()
    elif [ "$action" = "FORWARD" ]; then
        local tmpcmd
        $ECHO "$output" | $GREP "{}" > /dev/null
+
+       # SUBSTITION Feature
        # If {} is present that means pass the match pattern into the exec script.
        if [ $? -eq 0 ]; then
            local tmpmatch=$(shellmock_escape_special_chars $match)

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -38,23 +38,15 @@ skipIfNot()
     fi
 }
 
-#--------------------------------------------------------------
-# The arguments could have whitespace which we want to preserve
-# at times.  So we encapsulate all arguments with "
+#----------------------------------------------------------------------------
+# This function creates a single string containing all $*.  In the process
+# it checks to see if an arg contains a space and if so then it places
+# double quotes around the argument.
 #
-# Quotes in the matching process can cause issues.  This approach
-# would still have issues potentially if the arg separators are part of the input.
-#--------------------------------------------------------------
-shellmock_normalize_args2() {
-    shellmock_debug "shellmock_normalize_args: before *$**"
-    args=""
-    for arg in "$@"; do
-        args="$args$arg${SHELLMOCK_ARG_SEPARATOR}"
-    done
-    shellmock_debug "shellmock_normalize_args: after *$args*"
-    echo $args
-}
-
+# Note: Even if single quotes were originally used the string and
+# any matching in the ${capture{@]} arrary will have double quotes around
+# the arguments.
+#----------------------------------------------------------------------------
 shellmock_normalize_args() {
     shellmock_debug "shellmock_normalize_args: before *$**"
 
@@ -254,15 +246,20 @@ shellmock_expect()
         $ECHO "#!/usr/bin/env bash" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO "export BATS_TEST_DIRNAME=\"$BATS_TEST_DIRNAME\"" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO ". shellmock" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        if [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
+             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        else
+             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        fi
         $ECHO 'status=$?' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'if [ $status -ne 0 ]; then' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO '    shellmock_capture_err $0 failed ' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -277,7 +274,7 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    if [ "$MTYPE" != "X" ]; then
+    if [ "$MTYPE" != "X" ] && [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
         MATCH_NORM=`eval shellmock_normalize_args "$MATCH"`
     else
         MATCH_NORM=$MATCH
@@ -510,13 +507,12 @@ if [ -z "$WC" ]; then
     export WC=`which wc`
 fi
 
-# Allow consumers to redefine the separator if necessary.
-if [ -z $SHELLMOCK_ARG_SEPARATOR ]; then
-    export SHELLMOCK_ARG_SEPARATOR="~~"
-fi
-
 export BATS_TEST_DIRNAME
 export CAPTURE_FILE=$BATS_TEST_DIRNAME/shellmock.out
 export shellmock_capture_err=$BATS_TEST_DIRNAME/shellmock.err
 export shellmock_capture_debug=$BATS_TEST_DIRNAME/shellmock-debug.out
 export PATH=$BATS_TEST_DIRNAME/tmpstubs:$PATH
+
+if [ ! -z $SHELLMOCK_V1_COMPATIBILITY ]; then
+    shellmock_debug "shellmock: init: Running in V1 compatibility mode."
+fi

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -277,15 +277,8 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    MATCH=`shellmock_escape_escapes $MATCH`
-    shellmock_debug "shellmock_expect: save slashes *$MATCH*"
 
-    # Regex escapes have to be double escaped for the awk commands to work in the matching step.
-    if [ "$MTYPE" == "X" ]; then
-        MATCH=`shellmock_escape_escapes $MATCH`
-    fi
-
-    MATCH_NORM=`eval shellmock_normalize_args \"$MATCH\"`
+    MATCH_NORM=`shellmock_normalize_args $MATCH`
     shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
     if [ "$FORWARD" != "" ]; then
         $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -38,6 +38,43 @@ skipIfNot()
     fi
 }
 
+#--------------------------------------------------------------
+# The arguments could have whitespace which we want to preserve
+# at times.  So we encapsulate all arguments with "
+#
+# Quotes in the matching process can cause issues.  This approach
+# would still have issues potentially if the arg separators are part of the input.
+#--------------------------------------------------------------
+shellmock_normalize_args2() {
+    shellmock_debug "shellmock_normalize_args: before *$**"
+    args=""
+    for arg in "$@"; do
+        args="$args$arg${SHELLMOCK_ARG_SEPARATOR}"
+    done
+    shellmock_debug "shellmock_normalize_args: after *$args*"
+    echo $args
+}
+
+shellmock_normalize_args() {
+    shellmock_debug "shellmock_normalize_args: before *$**"
+
+    local re="[[:space:]]+"
+    args=""
+    for arg in "${@}";do
+      if [[ $arg =~ $re ]]; then
+          shellmock_debug "shellmock_normalize_args: found space: $arg"
+          args="$args \"$arg\""
+          shellmock_debug "shellmock_normalize_args: args: $args"
+      else
+          args="$args $arg"
+      fi
+      shellmock_debug "shellmock_normalize_args: args: $args"
+    done
+    args=`echo $args|$AWK '{$1=$1;print}'`
+    shellmock_debug "shellmock_normalize_args: after *$args*"
+    echo $args
+
+}
 #---------------------------------------------------------------------
 # The variables are being pas$SED to sed and / are important to sed
 # so before we send to sed and write to the detour.properties we will
@@ -45,9 +82,19 @@ skipIfNot()
 #---------------------------------------------------------------------
 shellmock_escape_special_chars()
 {
+    shellmock_debug "shellmock_escape_special_chars: args: $*"
     $ECHO "$*" | $SED -e 's/\//\\\//g' -e 's/\[/\\\[/g' -e 's/\]/\\\]/g'
 }
-
+#---------------------------------------------------------------------
+# The variables are being pas$SED to sed and / are important to sed
+# so before we send to sed and write to the detour.properties we will
+# use sed to replace any / with \/ then the later sed will succede.
+#---------------------------------------------------------------------
+shellmock_escape_escapes()
+{
+    shellmock_debug "shellmock_escape_escapes: args: $*"
+    $ECHO "$*" | $SED -e 's/\\/\\\\/g'
+}
 #--------------------------------------------------------------------------------------------------------------------------------------
 # This funciton is used to mock bash scripts.  It maps inputs to outputs and if a given script is
 # expecting varying results then they are played back in the order the expects were given.
@@ -79,7 +126,11 @@ shellmock_escape_quotes()
 mock_capture_match()
 {
     local MATCH=$(shellmock_escape_quotes $1)
-    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK  'BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
+    local IN_MATCH=$(shellmock_escape_quotes $2)
+    shellmock_debug "mock_capture_match: cmd: *$cmd* MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
+    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
+    shellmock_debug "mock_capture_match: awk script: $AWK_SCRIPT"
+    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK "$AWK_SCRIPT"
 }
 
 #------------------------------------
@@ -88,7 +139,12 @@ mock_capture_match()
 mock_state_match()
 {
     local MATCH=$(shellmock_escape_quotes $1)
-    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK  'BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print $2; if ($3=="P" && index("'"$MATCH"'",$1)) print $2;if ($3=="X" && match("'"$MATCH"'", $1)) print $2}' | $TAIL -1)
+    local IN_MATCH=$(shellmock_escape_quotes $2)
+    shellmock_debug "mock_state_match: cmd: $cmd MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
+    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print $2; if ($3=="P" && index("'"$MATCH"'",$1)) print $2;if ($3=="X" && match("'"$MATCH"'", $1)) print $2}'
+    shellmock_debug "mock_state_match: awk cmd: $AWK_SCRIPT"
+    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK "$AWK_SCRIPT" | $TAIL -1)
+    shellmock_debug "mock_state_match: rec: *$rec*"
     $ECHO $rec
 }
 
@@ -108,16 +164,19 @@ shellmock_expect()
     local OUTPUT=""
     local STATUS=0
     local MTYPE="E"
+    local IN_MTYPE="E"
 
 
-    #------------------------------------------------
+    #--------------------------------------------------------------
     # read the switches so we know what to do
     # --exec -- forward to another command
-    # --match -- arg list to the base command
+    # -m,--match,--match-args -- arg list to the base command for matching
+    # -M,--match-stdin -- stdin contents for arg matching
     # --output -- standard out that should be echoed
     # --status -- exit status to return
-    # --type  -- exact or partial
-    #------------------------------------------------
+    # -t,--type,--args-match-type  -- exact or partial of arg list
+    # -T,--stdin-match-type -- exact or partial match of stdin
+    #--------------------------------------------------------------
     while [[ $# -gt 1 ]]
     do
         local key="$1"
@@ -130,7 +189,7 @@ shellmock_expect()
                 FORWARD="$2"
                 shift # past argument
                 ;;
-            -t|--type)
+            -t|--type|--args-match-type)
                if [ "$2" = "partial" ];then
                    MTYPE="P"
                elif [ "$2" = "exact" ]; then
@@ -143,8 +202,25 @@ shellmock_expect()
                fi
                 shift # past argument
                 ;;
-            -m|--match)
+            -T|--stdin-match-type)
+               if [ "$2" = "partial" ];then
+                   IN_MTYPE="P"
+               elif [ "$2" = "exact" ]; then
+                   IN_MTYPE="E"
+               elif [ "$2" = "regex" ]; then
+                   IN_MTYPE="X"
+               else
+                   shellmock_capture_err "mock_expect type $2 not valid should be exact or partial"
+                   return 1
+               fi
+                shift # past argument
+                ;;
+            -m|--match|--match-args)
                 MATCH="$2"
+                shift # past argument
+                ;;
+            -M|--match-stdin)
+                MATCH_IN="$2"
                 shift # past argument
                 ;;
             -o|--output)
@@ -178,8 +254,15 @@ shellmock_expect()
         $ECHO "#!/usr/bin/env bash" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO "export BATS_TEST_DIRNAME=\"$BATS_TEST_DIRNAME\"" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO ". shellmock" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'status=$?' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'if [ $status -ne 0 ]; then' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO '    shellmock_capture_err $0 failed ' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -194,15 +277,25 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    if [ "$FORWARD" != "" ]; then
-        $ECHO "$MATCH@@FORWARD@@$FORWARD@@0@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
-    elif [ "$SOURCE" != "" ]; then
-        $ECHO "$MATCH@@SOURCE@@$SOURCE@@0@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
-    else
-        $ECHO "$MATCH@@OUTPUT@@$OUTPUT@@$STATUS@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    MATCH=`shellmock_escape_escapes $MATCH`
+    shellmock_debug "shellmock_expect: save slashes *$MATCH*"
+
+    # Regex escapes have to be double escaped for the awk commands to work in the matching step.
+    if [ "$MTYPE" == "X" ]; then
+        MATCH=`shellmock_escape_escapes $MATCH`
     fi
 
-    $ECHO "$MATCH@@1@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp"
+    MATCH_NORM=`eval shellmock_normalize_args \"$MATCH\"`
+    shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
+    if [ "$FORWARD" != "" ]; then
+        $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    elif [ "$SOURCE" != "" ]; then
+        $ECHO "$MATCH_NORM@@SOURCE@@$SOURCE@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    else
+        $ECHO "$MATCH_NORM@@OUTPUT@@$OUTPUT@@$STATUS@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    fi
+
+    $ECHO "$MATCH_NORM@@1@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp"
 
 }
 
@@ -213,8 +306,12 @@ shellmock_expect()
 #----------------------------------------
 shellmock_replay()
 {
-   cmd="$1"
-   match="$2"
+   local cmd="$1"
+   local match="$2"
+   local in_match="$3"
+
+   shellmock_debug "shellmock_replay: cmd: $cmd match: *$match* in_match: *$in_match*"
+
 
    local rec
    typeset -i rec
@@ -225,20 +322,22 @@ shellmock_replay()
    #-------------------------------------------------------------------------------------
    # Get the record index.  If there are multiple matches then they are returned in order
    #-------------------------------------------------------------------------------------
-   rec=$(mock_state_match "$match")
+   rec=$(mock_state_match "$match" "$in_match")
    if [ "$rec" = "0" ]; then
-       shellmock_capture_err "No record match found $cmd *$match*"
+       shellmock_capture_err "No record match found stdin:*$inmatch* cmd:$cmd args:*$match*"
        return 99
    fi
 
-   count=$(mock_capture_match "$match" | $WC -l)
-   entry=$(mock_capture_match "$match" | $HEAD -${rec} | $TAIL -1)
+   shellmock_debug "shellmock_replay: matched rec: $rec"
+   count=$(mock_capture_match "$match" "$in_match"| $WC -l)
+   entry=$(mock_capture_match "$match" "$in_match"| $HEAD -${rec} | $TAIL -1)
 
+   shellmock_debug "shellmock_replay: count: $count entry: $entry"
    #-------------------------------
    # If no entry is found then fail
    #-------------------------------
    if [ -z "$entry" ]; then
-       shellmock_capture_err "No match found for *$cmd* - *$match*"
+       shellmock_capture_err "No match found for stdin: *$in_match* cmd: *$cmd* - args: *$match*"
        exit 99
    fi
 
@@ -246,11 +345,19 @@ shellmock_replay()
    local output=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $3}')
    local status=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $4}')
    local mtype=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $5}')
+   local in_mtype=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $6}')
+
+   shellmock_debug "shellmock_replay: action: $action"
+   shellmock_debug "shellmock_replay: output: $output"
+   shellmock_debug "shellmock_replay: status: $status"
+   shellmock_debug "shellmock_replay: mtype: $mtype"
+   shellmock_debug "shellmock_replay: in_mtype: $in_mtype"
 
    #--------------------------------------------------------------------------------------
    # If there are multiple responses for a given match then keep track of a response index
    #--------------------------------------------------------------------------------------
    if [ "$count" -gt 1 ]; then
+       shellmock_debug "shelmock_replay: multiple matches: $count"
        $CP "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp" "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak"
        $CAT "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak" | $AWK 'BEGIN{FS="@@"}{ if (($3=="E" && $1=="'"$match"'")||($3=="P"&& index("'"$match"'",$1))||($3=="X" && match("'"$match"'",$1))) printf("%s@@%d@@%s\n",$1,$2+1,$3) ; else printf("%s@@%d@@%s\n",$1,$2,$3) }' > "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp"
    fi
@@ -259,6 +366,7 @@ shellmock_replay()
    # If this is a command forwarding request then call the command
    #--------------------------------------------------------------
    if [ "$action" = "SOURCE" ]; then
+       shellmock_debug "shellmock_replay: perform: SOURCE *. $output*"
        . $output
        return $?
 
@@ -271,7 +379,8 @@ shellmock_replay()
            tmpcmd=$($ECHO "$output" | $SED "s/{}/$tmpmatch/g")
        else
            tmpcmd=$output
-        fi
+       fi
+       shellmock_debug "shellmock_replay: perform: FORWARD *$tmpcmd*"
        $tmpcmd
        return $?
 
@@ -279,6 +388,7 @@ shellmock_replay()
    # Otherwise return the output
    #----------------------------
    else
+       shellmock_debug "shellmock_replay: perform: OUTPUT *$output* STATUS: $status"
        $ECHO "$output" | $AWK 'BEGIN{FS="%%"}{ for (i=1;i<=NF;i++) {print $i}}'
        return $status
    fi
@@ -289,8 +399,9 @@ shellmock_replay()
 #-------------------------------
 shellmock_capture_cmd()
 {
+    local cmd=`echo "$@" | awk '{$1=$1};1'`
     # trim leading and trailing spaces from the command
-    cmd=`echo "$*" | awk '{$1=$1};1'`
+    shellmock_debug "shellmock_capture_cmd: captured: *$cmd*"
     $ECHO "${cmd}" >> "$CAPTURE_FILE"
 }
 
@@ -400,7 +511,10 @@ if [ -z "$WC" ]; then
     export WC=`which wc`
 fi
 
-
+# Allow consumers to redefine the separator if necessary.
+if [ -z $SHELLMOCK_ARG_SEPARATOR ]; then
+    export SHELLMOCK_ARG_SEPARATOR="~~"
+fi
 
 export BATS_TEST_DIRNAME
 export CAPTURE_FILE=$BATS_TEST_DIRNAME/shellmock.out

--- a/sample-bats/sample.bats
+++ b/sample-bats/sample.bats
@@ -64,14 +64,12 @@ teardown()
 }
 
 #-----------------------------------------------------------------------------------
-# This test case demonstrates a normal bats test case where sample.sh is under test.
-# sample.sh will echo "sample found" based on the response to the grep command.
-# The default output will always be "sample found" because the script ensures
-# that grep will return 0.
+# This test case demonstrates mocking the grep command using the partial mock feature.
+# The sample.sh calls grep with two arguments.  The first argument is "sample line".
 #-----------------------------------------------------------------------------------
 @test "sample.sh-success-partial-mock" {
 
-    shellmock_expect grep --status 0 --output "Mocked output for Partial Match" --type partial --match '"sample line"'
+    shellmock_expect grep --status 0 --type partial --match '"sample line"'
 
     run ./sample.sh
 
@@ -86,6 +84,39 @@ teardown()
     [ "$output" = "sample found" ]
 
     shellmock_verify
+    [ "${#capture[@]}" = "1" ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+
+}
+
+#-----------------------------------------------------------------------------------
+# This test case demonstrates mocking the grep command using the partial mock feature.
+# The sample.sh calls grep with two arguments.  The first argument is "sample line".
+#
+# The only difference between this and the previous test is that the argument is passed
+# as single quotes 'sample line'.
+#
+# In that case you will notice that the command[] matches show as double quotes vs
+# single quotes. That is because the arguments are normalized to double quotes.
+#-----------------------------------------------------------------------------------
+@test "sample.sh-success-partial-mock-with-single-quotes" {
+
+    shellmock_expect grep --status 0 --type partial --match '"sample line"'
+
+    run ./sample.sh
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "1" ]
     [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }

--- a/sample-bats/sample.bats
+++ b/sample-bats/sample.bats
@@ -63,6 +63,33 @@ teardown()
 
 }
 
+#-----------------------------------------------------------------------------------
+# This test case demonstrates a normal bats test case where sample.sh is under test.
+# sample.sh will echo "sample found" based on the response to the grep command.
+# The default output will always be "sample found" because the script ensures
+# that grep will return 0.
+#-----------------------------------------------------------------------------------
+@test "sample.sh-success-partial-mock" {
+
+    shellmock_expect grep --status 0 --output "Mocked output for Partial Match" --type partial --match '"sample line"'
+
+    run ./sample.sh
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+
+}
+
 #----------------------------------------------------------------------------------------
 # This test case demonstrates that the else condition if grep does not find the match.
 # By forcing the status of 1 grep will cause the "sample not found" message to be echoed.
@@ -84,6 +111,6 @@ teardown()
 
 
     shellmock_verify
-    [ "${capture[0]}" = 'grep-stub sample line sample.out' ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -66,7 +66,7 @@ teardown()
     [ "$output" = "mock a b failed" ]
 }
 
-@test "shellmock_expect multiple responses" {
+@test "shellmock_expect-multiple-responses" {
 
     skipIfNot multi-resources
 
@@ -120,7 +120,7 @@ teardown()
     run cp a c
     [ "$status" = "99" ]
 
-    grep 'No record match found cp \*a c\*' shellmock.err
+    grep 'No record match found stdin:\*\* cmd:cp args:\*a c\*' shellmock.err
 
 }
 
@@ -141,7 +141,7 @@ teardown()
 
     run cp b b
     [ "$status" = "99" ]
-    grep 'No record match found cp \*b b\*' shellmock.err
+    grep 'No record match found stdin:\*\* cmd:cp args:\*b b\*' shellmock.err
 
 }
 
@@ -310,13 +310,14 @@ teardown()
     skipIfNot regex-match
 
     shellmock_clean
-    shellmock_expect cp --status 0 --type regex --match "-a -s script\(\'t.*\)" --output "mock success"
+    shellmock_expect cp --status 0 --type regex --match "-a -s script\(\'t.*\'\)" --output "mock success"
 
     run cp -a -s "script('testit')"
     [ "$status" = "0" ]
     [ "$output" = "mock success" ]
 
     run cp -a -s "script('testit2')"
+
     [ "$status" = "0" ]
     [ "$output" = "mock success" ]
 

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -28,6 +28,7 @@ setup()
 {
     # For testing setup the path so that install is not required.
     export PATH=../bin:$PATH
+    unset SHELLMOCK_V1_COMPATIBILITY
     . shellmock
 
 }
@@ -485,3 +486,19 @@ teardown()
 
 }
 
+@test "shellmock_expect quotes compatibility test" {
+
+    skipIfNot quotes-compatibility-v1.0-test
+
+    export SHELLMOCK_V1_COMPATIBILITY="enabled"
+
+    shellmock_clean
+    shellmock_expect cp --status 0 --match "a b c" --output "mock a b success"
+
+    run cp "a b" c
+    [ "$status" = "0" ]
+    [ "$output" = "mock a b success" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = "cp-stub a b c" ]
+}

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -106,6 +106,24 @@ teardown()
 
 }
 
+@test "shellmock_expect --status 0 partial-match with double quotes" {
+
+    skipIfNot partial-match
+
+    shellmock_clean
+    shellmock_expect cp --status 0 --type partial --match '"a file.c"' --output "mock success"
+
+    run cp "a file.c" b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run cp "a file.c" c
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+}
+
+
 @test "shellmock_expect failed matches" {
 
     skipIfNot failed-matches


### PR DESCRIPTION
- Added logic to normalize arguments by looking for white space and recreating the match arguments with those arguments with spaces into one quoted argument. 
- Added additional test cases and examples

This change does have a compatibility change from previous implementation.

If a test case has input '"a b" c' today then previously the capture[0] = "a b c" would not be capture[0] = '"a b" c'.

Like wise if the old match logic was --match "a b c" and the stub was called with "a b" c then the match logic will no longer work with the new approach.