### PR TITLE
Resolves issue #25 - Improper handling of quoted arguments with white space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/sample-bats/tmpstubs/
+.idea
+*.out
+*.err

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ the "output" as the exit status and any standard output. In addition it will all
  advanced test cases may require new behavior.
 
 Given the bash command "cp file1 file2", a stub might be defined to return status 0.  The stub could also echo "cp file1 file2" to standard out.  Using Bats **status**, **line** or **output** variables
-you can verify that "cp file1 fil2" was written which would confirm that the script was called.  The example below is a snippet from a **bats** script. It is assumed that **mycmd** is the script being testing and it calls "cp file1 file2" during its execution.
+you can verify that "cp file1 file2" was written which would confirm that the script was called.  The example below is a snippet from a **bats** script. It is assumed that **mycmd** is the script being tested and it calls "cp file1 file2" during its execution.
 
 ```bats
 run mycmd
@@ -35,14 +35,23 @@ One approach for stubbing is to create bash scripts with the same names as the r
 
 == Enabling Mocks in your Bats tests
 
-The first step is to source **shellmock** in the **setup()** function and call the **shellmock_cleanup** function from the bats **teardown** function.  To assist in troubleshooting a new variable **TEST_FUNCTION** was added that
-can be used to restrict testing to a single function and skipping all others.  In that case I choose not to clean up so that I can better troubleshoot any test failures associated with mocking.  The section below is boiler plate and I would add to all my test files.
+The first step is to source **shellmock** in the **setup()** function and call the **shellmock_cleanup** function from the bats **teardown** function.  These two steps will make **shellmock** functions available
+to your testcases and perform appropriate cleanup in between tests.
 
+Adding the **skipIfNot** function in **setup()** will help with troubleshooting.  This will allow
+users to define the **TEST_FUNCTION** environment variable to run a single test and turn on the associated debug logs.
+
+The link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo provides an example of how to setup **shellmock** in a **bats** script.
 ```bash
 
 setup()
 {
+    # Source the shellmock functions into the shell.
     . shellmock
+
+    skipIfNot "$BATS_TEST_DESCRIPTION"
+
+    shellmock_clean
 }
 
 teardown()
@@ -57,9 +66,10 @@ teardown()
 == Environment Variables
 |===
 | Name | Purpose
-| TEST_FUNCTION | Bats variable the is used to control debugging i shellmock. When
+| TEST_FUNCTION | Shellmock variable that is used to run single tests and control debugging output in shellmock. When
 set to the name of a test case then all tmp and debug output is
-preserved.
+preserved after the test completes.  If you give each test a unique name then only that one test will be executed.  You have to leverage the **skipIfNot** function in **setup** or in the
+test case to take advantage of the feature.
 | SHELLMOCK_V1_COMPATIBILITY | v1.2 introduced logic that handles matching
 arguments differently when they contain spaces.  As a result old tests
 could fail to match.  This flag allows the old tests to continue to pass.
@@ -67,18 +77,78 @@ could fail to match.  This flag allows the old tests to continue to pass.
 
 == Adding Mocks in one of your tests
 
-In the link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo, the status code from **grep** is used to control the logic flow of the script.  We can use Shellmock's **shellmock_expect** command to simulate a failure scenario when the target parameters are seen.
-In the snippet below the return status will be "1" when the command line arguments are **"sample" sample.out**.  If **grep** is called with any other arguments then a failure will be returned with status **99**.
+In the link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo, the status code from **grep** is used to control the logic flow of the script.  We can use Shellmock's **shellmock_expect** command to simulate various success and failures scenarios depending on the arguments and stdin passed into the **grep** command.
+
+**sample.sh**
+```bash
+echo "sample line 1"  > sample.out
+
+grep "sample line" sample.out > /dev/null
+if [ $? -ne 0 ]; then
+    echo "sample not found"
+    exit 1
+fi
+
+echo "sample found"
+```
+
+In the sections that follow we will create some test cases against **sample.sh**.
+
+=== Success Scenario using exact matching
+This testcase is simply using bats and calling the real **grep** command.  No mocking was involved.  This was included to
+show that testcases can be a mixture of mocks and real commands.
+
+```bash
+@test "sample.sh-success" {
+
+    run ./sample.sh
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+}
+```
+
+=== Failure Scenario using exact matching
+In this failure scenario we are creating a stub that will return a status of 1 if the input arguments to **grep** is called as below:
+
+```
+grep "sample line" sample.out.
+
+or
+
+grep 'sample line' sample.out
+
+NOTE: These will look the same in the stub's input args.
+```
+
+The testcase is using the default match type which is an exact match.
 
 ```bash
 @test "sample.sh-failure" {
 
-    shellmock_expect grep --status 1 --match '"sample" sample.out'
+
+    shellmock_expect grep --status 1 --match '"sample line" sample.out'
+
+    shellmock_debug "starting the test"
 
     run ./sample.sh
+
+    # Only significant when debugging is occurring it captures bats variables to output files
+    # to make it easier to see what you are missing.
+    shellmock_dump
+
     [ "$status" = "1" ]
     [ "$output" = "sample not found" ]
 
+    # called to create the capture array to allow expect verifications.
+    shellmock_verify
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }
 ```
@@ -86,24 +156,105 @@ In the snippet below the return status will be "1" when the command line argumen
 After the status and output of the script has been validated as needed, then the final piece is to verify that all of the expected mocks were called. The function **shellmock_verify** reads the **shellmock.out** file which contains a record
 of all mock invocations.  The lines of the file are written to an array variable called **capture**.
 
-As you will note there are some challenges with quotes in the verifcation pass.  The quotes do not exist in the verification line.  There maybe ways to preserve them, but initially it proved to be a challenge.  This was good enough for me for now.
+NOTE: Arguments that contain quotes in them were a challenge.  The scripting cannot tell the difference between single or double quotes.
+Therefore when single quotes are specified in the matching then **shellmock** converts them to double quotes.  The capture output will contain double quotes even if
+the original script was called with single quotes.
 
+The original version 1 did not make any distinction and this new feature was added in v2.  In v1 no quotes would appear in the verification output.  It would appear like three arguments instead of two.
+
+=== Success Scenario leveraging a partial mock
+In this test scenario we are only matching one of the arguments: "sample line".  Any filename could be passed and still match the mock.
 
 ```bash
-@test "sample.sh-failure" {
+@test "sample.sh-success-partial-mock" {
 
-    shellmock_expect grep --status 1 --match '"sample line" sample.out'
+    shellmock_expect grep --status 0 --type partial --match '"sample line"'
 
     run ./sample.sh
-    [ "$status" = "1" ]
-    [ "$output" = "sample not found" ]
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
 
     shellmock_verify
-    [ "${capture[0]}" = 'grep-stub sample line sample.out' ]
+    [ "${#capture[@]}" = "1" ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }
 ```
 
+=== Success Scenario demonstrating single vs double quotes
+This testcase is the same as the one above except that single quotes where
+used around the argument.
+
+```bash
+@test "sample.sh-success-partial-mock-with-single-quotes" {
+
+    shellmock_expect grep --status 0 --type partial --match "'sample line'"
+
+    run ./sample.sh
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "1" ]
+
+    # Note that it is "sample line" in the capture output.
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+
+}
+```
+
+=== Scenario with RegEx matching
+This scenario was easier to show just using grep directly from the bats file.
+I created two mocks for grep, one with file names that start with 's' and one with
+file names starting with 'b'.  There two mocks return 0 and 1 respectively.
+
+```bash
+@test "sample.sh-mock-with-regex" {
+
+    shellmock_expect grep --status 0 --type regex --match '"sample line" s.*'
+    shellmock_expect grep --status 1 --type regex --match '"sample line" b.*'
+
+    # The first two patterns leverage the first mock.
+    run grep "sample line" sample.out
+    [ "$status" = "0" ]
+
+    run grep "sample line" sample1.out
+    [ "$status" = "0" ]
+
+    # These two patterns leverage the second mock.
+    run grep "sample line" bfile.out
+    [ "$status" = "1" ]
+
+    run grep "sample line" bats.out
+    [ "$status" = "1" ]
+
+    shellmock_dump
+
+    shellmock_verify
+    [ "${#capture[@]}" = "4" ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+    [ "${capture[1]}" = 'grep-stub "sample line" sample1.out' ]
+    [ "${capture[2]}" = 'grep-stub "sample line" bfile.out' ]
+    [ "${capture[3]}" = 'grep-stub "sample line" bats.out' ]
+
+}
+```
 To see a demonstration of the sample tests running, you will first need to install **shellmock** as described later and then follow the steps below.
 
 ```
@@ -115,8 +266,12 @@ You should expect to see output as follows:
 ```
  ✓ sample.sh-success
  ✓ sample.sh-failure
+ ✓ sample.sh-success-partial-mock
+ ✓ sample.sh-success-partial-mock-with-single-quotes
+ ✓ sample.sh-mock-with-regex
 
-2 tests, 0 failures
+5 tests, 0 failures
+
 ```
 == Shellmock Functions
 
@@ -187,8 +342,8 @@ TEST_FUNCTION is set.
 will dump the contains of the **bats** **$lines** variable which basically equates to
 any standard out that has been generated by the script under test.
 
-The output is captured in shellmock-debut.out and will only be available if
-TEST_FUNCTION is set.
+The output is captured in shellmock-debug.out and will only be available if
+**TEST_FUNCTION** is set.
 
 === shellmock_verify
 
@@ -215,7 +370,7 @@ behavior that you provide.
 |===
 |**Item**|**Description**|**Required?**
 |cmd|unix command to mock|Yes.
-|--type|Type of match **partial** or **exact**|No. Defaults to **exact**
+|--type|Type of match **partial** or **exact** or **regex**|No. Defaults to **exact**
 |--match|Arguments passed to cmd that indicate a match to mock.|Yes.
 |--exec|Command string to execute for custom behavior.|No.
 |--source|Command string to source.|No.
@@ -227,17 +382,17 @@ behavior that you provide.
 
 ==== examples
 
-These examples assume that the "grep string1 file1" is the unix command being mocked.
+These examples assume that the "grep string1 file1" is the unix command being mocked to be used in other scripts under test. For
+simplicity of understanding, I am calling the **grep** command directly from bats to show what the behavior would look like.
 
 ===== Basic mock with success status
-
-If the **grep** command is run by a script under test it will return the default status of 0.  In order
-to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
+This example mocks **grep** to return a 0 status when the input is "string1 file1".
+In order to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
 
 ```bash
 shellmock_expect grep --match "string1 file2"
 
-run testscript.sh
+run grep string1 file2
 [ "$status" = "0" ]
 
 shellmock_verify
@@ -248,13 +403,12 @@ shellmock_verify
 
 ===== Basic mock with failed status
 
-If the **grep** command is run by a script under test it will return the status of 1.  In order
-to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
+This scenario show a status of 1 being returned for the same inputs.
 
 ```bash
 shellmock_expect grep --status 1 --match "string1 file2"
 
-run testscript.sh
+run grep string1 file2
 [ "$status" = "1" ]
 
 shellmock_verify
@@ -265,13 +419,15 @@ shellmock_verify
 
 ===== Mock with partial mock
 
-If the **grep** command is run by the script under test it will return a status 0 if arg1 is "string1" regardless of the rest of the args.  In order
-to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
+If the **grep** command is run it will return a status 0 if arg1 is "string1" regardless of the rest of the args. Use **shellmock_verify** verify each invocation if desired.
 
 ```bash
 shellmock_expect grep --status 0 --type partial --match string1
 
-run testscript.sh
+run grep string1 file2
+[ "$status" = "0" ]
+
+run grep string1 file3
 [ "$status" = "0" ]
 
 shellmock_verify
@@ -287,14 +443,15 @@ If the **grep** command is run by the script under test it will return a status 
 to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
 
 If the --match argument were "'string1 string2' file", where the double quotes and single quotes are
-swapped, then shellmock treats the string as if it were '"string1 string2" file'.  That will be evident in the
-capture array.  This is due to how the shell treats " and '.  Shellmock can not always tell the difference so we have
-normalized them to double quotes.
+swapped, then shellmock treats the string as if it were '"string1 string2" file'.
 
 ```bash
-shellmock_expect grep --status 0 --type partial --match '"string1 string2" file'
+shellmock_expect grep --status 0 --type partial --match '"string1 string2"'
 
-run testscript.sh
+run grep "string1 string2" file2
+[ "$status" = "0" ]
+
+run grep "string1 string2" file3
 [ "$status" = "0" ]
 
 shellmock_verify
@@ -305,15 +462,18 @@ shellmock_verify
 ```
 
 ===== Mock with regex
+This example shows the use of regex match type.
 
-If the **grep** command is run by the script under test it will return a status 0 if arg1 starts with an 's' and arg2 starts with an 'f'.
-
-The regular expression is evaluated by the *AWK* command.  Refer to *AWK* documentation for details.
+The regular expression is evaluated by the *AWK* command.  Refer to *AWK* documentation for details. Any *AWK*
+special characters will need to be escaped in the match criteria.
 
 ```bash
 shellmock_expect grep --status 0 --type regex --match "s.* f.*"
 
-run testscript.sh
+run grep string1 file2
+[ "$status" = "0" ]
+
+run grep string1 file3
 [ "$status" = "0" ]
 
 shellmock_verify
@@ -322,43 +482,36 @@ shellmock_verify
 
 ```
 
+===== Mock with custom script
 
-===== Mock with custom behavior with custom input args
-
-If the **grep** command is run by a script under test it will execute the custom script called "stubs/mycustom" and pass "tag1" as input.  By passing {} to the script then
-**shellmock** will replace {} with $* so that you will get all of the matched arguments passed into the custom script as well.
+If the **grep** command is run by a script under test it will return a status 0 if arg1 is "string1" and arg2 is "file1".  It will also write "mycustom string1 file1" to stdout.  The use of the {}
+in the --exec script will cause any arguments passed to the mocked script to be expanded in place of the braces as seen below.
 
 For this example you can verify the **status**, the **output**/**line**, and the **capture** variables.
 
 ```bash
-shellmock_expect grep --status 0 --type exact --match "string1 file1" -exec "stubs/mycustom tag1 {}"
+    shellmock_expect grep --status 0 --type partial --match "string1" --exec "echo mycustom {}"
 
-run testscript.sh
-[ "$status" = "0" ]
-[ "${line[0]}" = "mycustom output1" ]
-[ "${line[1]}" = "mycustom output2" ]
+    run grep string1 file1
 
-shellmock_verify
-[ "${capture[0]} = "grep-stub tag1 string1 file1" ]
+    shellmock_dump
+    [ "$status" = "0" ]
+    [ "${lines[0]}" = "mycustom string1 file1" ]
 
-```
+    run grep string1 file2
+    shellmock_dump
+    [ "$status" = "0" ]
+    [ "${lines[0]}" = "mycustom string1 file2" ]
 
-===== Mock with custom output
-
-If the **grep** command is run by a script under test it will return a status 0 if arg1 is "string1" and arg2 is "file1".  It will also write "some cool text" to stdout.
-For this example you can verify the **status**, the **output**/**line**, and the **capture** variables.
-
-```bash
-shellmock_expect grep --status 0 --type exact --match "string1 file1" --output "some cool text"
-
-run testscript.sh
-[ "$status" = "0" ]
-[ "${line[0]}" = "some cool text" ]
-
-shellmock_verify
-[ "${capture[0]} = "grep-stub string1 file1" ]
+    shellmock_verify
+    [ "${#capture[@]}" = "2" ]
+    [ "${capture[0]}" = 'grep-stub string1 file1' ]
+    [ "${capture[1]}" = 'grep-stub string1 file2' ]
 
 ```
+
+This example shows the use of **echo** as the script, however, it could also be any user defined script that you
+want in place of the mocked command.  The {} braces are a way to forward arguments from the mock script into your script.
 
 == Installing Bash Shell Mock from source
 

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ The first step is to source **shellmock** in the **setup()** function and call t
 to your testcases and perform appropriate cleanup in between tests.
 
 Adding the **skipIfNot** function in **setup()** will help with troubleshooting.  This will allow
-users to define the **TEST_FUNCTION** environment variable to run a single test and turn on the associated debug logs.
+users to define the **TEST_FUNCTION** environment variable to run a single test or a subset of tests and turn on the associated debug logs.
 
 The link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo provides an example of how to setup **shellmock** in a **bats** script.
 ```bash
@@ -77,11 +77,11 @@ could fail to match.  This flag allows the old tests to continue to pass.
 
 == Adding Mocks in one of your tests
 
-In the link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo, the status code from **grep** is used to control the logic flow of the script.  We can use Shellmock's **shellmock_expect** command to simulate various success and failures scenarios depending on the arguments and stdin passed into the **grep** command.
+In the link:sample-bats/sample.sh[sample.sh] script provided in the **shellmock** repo, the status code from **grep** is used to control the logic flow of the script.  We can use Shellmock's **shellmock_expect** command to simulate various success and failures scenarios depending on the arguments passed into the **grep** command.
 
 **sample.sh**
 ```bash
-echo "sample line 1"  > sample.out
+echo "sample line"  > sample.out
 
 grep "sample line" sample.out > /dev/null
 if [ $? -ne 0 ]; then
@@ -115,7 +115,7 @@ show that testcases can be a mixture of mocks and real commands.
 ```
 
 === Failure Scenario using exact matching
-In this failure scenario we are creating a stub that will return a status of 1 if the input arguments to **grep** is called as below:
+In this failure scenario we are creating a stub that will return a status of 1 if the **grep** is called in one of the two ways below:
 
 ```
 grep "sample line" sample.out.
@@ -160,7 +160,7 @@ NOTE: Arguments that contain quotes in them were a challenge.  The scripting can
 Therefore when single quotes are specified in the matching then **shellmock** converts them to double quotes.  The capture output will contain double quotes even if
 the original script was called with single quotes.
 
-The original version 1 did not make any distinction and this new feature was added in v2.  In v1 no quotes would appear in the verification output.  It would appear like three arguments instead of two.
+The original version 1 did not make any distinction and this new feature was added in version 2.  In v1 no quotes would appear in the verification output.  It would appear like three arguments were passed instead of two.
 
 === Success Scenario leveraging a partial mock
 In this test scenario we are only matching one of the arguments: "sample line".  Any filename could be passed and still match the mock.
@@ -222,7 +222,7 @@ used around the argument.
 === Scenario with RegEx matching
 This scenario was easier to show just using grep directly from the bats file.
 I created two mocks for grep, one with file names that start with 's' and one with
-file names starting with 'b'.  There two mocks return 0 and 1 respectively.
+file names starting with 'b'.  The two mocks return 0 and 1 respectively.
 
 ```bash
 @test "sample.sh-mock-with-regex" {
@@ -273,7 +273,11 @@ You should expect to see output as follows:
 5 tests, 0 failures
 
 ```
+
+The test bats files are another good source for examples as it contains examples of all of the **shellmock** features.
+
 == Shellmock Functions
+This section contains a list of the function provided by **shellmock** also with example usages.
 
 === skipIfNot
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,16 @@ teardown()
 
 ```
 
+== Environment Variables
+|===
+| Name | Purpose
+| TEST_FUNCTION | Bats variable the is used to control debugging i shellmock. When
+set to the name of a test case then all tmp and debug output is
+preserved.
+| SHELLMOCK_V1_COMPATIBILITY | v1.2 introduced logic that handles matching
+arguments differently when they contain spaces.  As a result old tests
+could fail to match.  This flag allows the old tests to continue to pass.
+|===
 
 == Adding Mocks in one of your tests
 

--- a/README.adoc
+++ b/README.adoc
@@ -231,6 +231,7 @@ run testscript.sh
 [ "$status" = "0" ]
 
 shellmock_verify
+[ "${capture[@]} = 1 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 
 ```
@@ -247,6 +248,7 @@ run testscript.sh
 [ "$status" = "1" ]
 
 shellmock_verify
+[ "${capture[@]} = 1 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 
 ```
@@ -263,8 +265,32 @@ run testscript.sh
 [ "$status" = "0" ]
 
 shellmock_verify
+[ "${capture[@]} = 2 ]
 [ "${capture[0]} = "grep-stub string1 file2" ]
 [ "${capture[1]} = "grep-stub string1 file3" ]
+
+```
+
+===== Mock with whitespace in the parameters
+
+If the **grep** command is run by the script under test it will return a status 0 if arg1 is "string1" regardless of the rest of the args.  In order
+to verify that the function was called you would need to use **shellmock_verify** and do a comparison.
+
+If the --match argument were "'string1 string2' file", where the double quotes and single quotes are
+swapped, then shellmock treats the string as if it were '"string1 string2" file'.  That will be evident in the
+capture array.  This is due to how the shell treats " and '.  Shellmock can not always tell the difference so we have
+normalized them to double quotes.
+
+```bash
+shellmock_expect grep --status 0 --type partial --match '"string1 string2" file'
+
+run testscript.sh
+[ "$status" = "0" ]
+
+shellmock_verify
+[ "${capture[@]} = 2 ]
+[ "${capture[0]} = 'grep-stub "string1 string2" file2' ]
+[ "${capture[1]} = 'grep-stub "string1 string2" file3' ]
 
 ```
 
@@ -303,7 +329,7 @@ run testscript.sh
 [ "${line[1]}" = "mycustom output2" ]
 
 shellmock_verify
-[ "${capture[0]} = "grep-stub string1 file1" ]
+[ "${capture[0]} = "grep-stub tag1 string1 file1" ]
 
 ```
 

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -277,8 +277,12 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
+    if [ "$MTYPE" != "X" ]; then
+        MATCH_NORM=`eval shellmock_normalize_args "$MATCH"`
+    else
+        MATCH_NORM=$MATCH
+    fi
 
-    MATCH_NORM=`shellmock_normalize_args $MATCH`
     shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
     if [ "$FORWARD" != "" ]; then
         $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
@@ -366,6 +370,8 @@ shellmock_replay()
    elif [ "$action" = "FORWARD" ]; then
        local tmpcmd
        $ECHO "$output" | $GREP "{}" > /dev/null
+
+       # SUBSTITION Feature
        # If {} is present that means pass the match pattern into the exec script.
        if [ $? -eq 0 ]; then
            local tmpmatch=$(shellmock_escape_special_chars $match)

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -62,7 +62,7 @@ shellmock_normalize_args() {
       fi
       shellmock_debug "shellmock_normalize_args: args: $args"
     done
-    args=`echo $args|$AWK '{$1=$1;print}'`
+    args=$(echo $args|$AWK '{$1=$1;print}')
     shellmock_debug "shellmock_normalize_args: after *$args*"
     echo $args
 
@@ -254,8 +254,8 @@ shellmock_expect()
 #        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
 #        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         if [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
-             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-             $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$(shellmock_normalize_args "$@")"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"$(shellmock_normalize_args "$@")"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         else
              $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
              $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -275,7 +275,7 @@ shellmock_expect()
     #
     #---------------------------------------------------------------
     if [ "$MTYPE" != "X" ] && [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
-        MATCH_NORM=`eval shellmock_normalize_args "$MATCH"`
+        MATCH_NORM=$(eval shellmock_normalize_args "$MATCH")
     else
         MATCH_NORM=$MATCH
     fi
@@ -395,7 +395,7 @@ shellmock_replay()
 #-------------------------------
 shellmock_capture_cmd()
 {
-    local cmd=`echo "$@" | awk '{$1=$1};1'`
+    local cmd=$(echo "$@" | awk '{$1=$1};1')
     # trim leading and trailing spaces from the command
     shellmock_debug "shellmock_capture_cmd: captured: *$cmd*"
     $ECHO "${cmd}" >> "$CAPTURE_FILE"
@@ -468,43 +468,43 @@ shellmock_verify()
 # key commands it needs.
 #-------------------------------------------------------------------------------------------------------
 if [ -z "$ECHO" ]; then
-    export ECHO=`which echo`
+    export ECHO=$(which echo)
 fi
 if [ -z "$CP" ]; then
-    export CP=`which cp`
+    export CP=$(which cp)
 fi
 if [ -z "$CAT" ]; then
-    export CAT=`which cat`
+    export CAT=$(which cat)
 fi
 if [ -z "$RM" ]; then
-    export RM=`which rm`
+    export RM=$(which rm)
 fi
 if [ -z "$AWK" ]; then
-    export AWK=`which awk`
+    export AWK=$(which awk)
 fi
 if [ -z "$GREP" ]; then
-    export GREP=`which grep`
+    export GREP=$(which grep)
 fi
 if [ -z "$MKDIR" ]; then
-    export MKDIR=`which mkdir`
+    export MKDIR=$(which mkdir)
 fi
 if [ -z "$TOUCH" ]; then
-    export TOUCH=`which touch`
+    export TOUCH=$(which touch)
 fi
 if [ -z "$CHMOD" ]; then
-    export CHMOD=`which chmod`
+    export CHMOD=$(which chmod)
 fi
 if [ -z "$SED" ]; then
-    export SED=`which sed`
+    export SED=$(which sed)
 fi
 if [ -z "$HEAD" ]; then
-    export HEAD=`which head`
+    export HEAD=$(which head)
 fi
 if [ -z "$TAIL" ]; then
-    export TAIL=`which tail`
+    export TAIL=$(which tail)
 fi
 if [ -z "$WC" ]; then
-    export WC=`which wc`
+    export WC=$(which wc)
 fi
 
 export BATS_TEST_DIRNAME

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -38,23 +38,15 @@ skipIfNot()
     fi
 }
 
-#--------------------------------------------------------------
-# The arguments could have whitespace which we want to preserve
-# at times.  So we encapsulate all arguments with "
+#----------------------------------------------------------------------------
+# This function creates a single string containing all $*.  In the process
+# it checks to see if an arg contains a space and if so then it places
+# double quotes around the argument.
 #
-# Quotes in the matching process can cause issues.  This approach
-# would still have issues potentially if the arg separators are part of the input.
-#--------------------------------------------------------------
-shellmock_normalize_args2() {
-    shellmock_debug "shellmock_normalize_args: before *$**"
-    args=""
-    for arg in "$@"; do
-        args="$args$arg${SHELLMOCK_ARG_SEPARATOR}"
-    done
-    shellmock_debug "shellmock_normalize_args: after *$args*"
-    echo $args
-}
-
+# Note: Even if single quotes were originally used the string and
+# any matching in the ${capture{@]} arrary will have double quotes around
+# the arguments.
+#----------------------------------------------------------------------------
 shellmock_normalize_args() {
     shellmock_debug "shellmock_normalize_args: before *$**"
 
@@ -254,15 +246,20 @@ shellmock_expect()
         $ECHO "#!/usr/bin/env bash" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO "export BATS_TEST_DIRNAME=\"$BATS_TEST_DIRNAME\"" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO ". shellmock" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+#        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        if [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
+             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        else
+             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        fi
         $ECHO 'status=$?' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'if [ $status -ne 0 ]; then' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO '    shellmock_capture_err $0 failed ' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -277,7 +274,7 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    if [ "$MTYPE" != "X" ]; then
+    if [ "$MTYPE" != "X" ] && [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
         MATCH_NORM=`eval shellmock_normalize_args "$MATCH"`
     else
         MATCH_NORM=$MATCH
@@ -510,13 +507,12 @@ if [ -z "$WC" ]; then
     export WC=`which wc`
 fi
 
-# Allow consumers to redefine the separator if necessary.
-if [ -z $SHELLMOCK_ARG_SEPARATOR ]; then
-    export SHELLMOCK_ARG_SEPARATOR="~~"
-fi
-
 export BATS_TEST_DIRNAME
 export CAPTURE_FILE=$BATS_TEST_DIRNAME/shellmock.out
 export shellmock_capture_err=$BATS_TEST_DIRNAME/shellmock.err
 export shellmock_capture_debug=$BATS_TEST_DIRNAME/shellmock-debug.out
 export PATH=$BATS_TEST_DIRNAME/tmpstubs:$PATH
+
+if [ ! -z $SHELLMOCK_V1_COMPATIBILITY ]; then
+    shellmock_debug "shellmock: init: Running in V1 compatibility mode."
+fi

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -277,15 +277,8 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    MATCH=`shellmock_escape_escapes $MATCH`
-    shellmock_debug "shellmock_expect: save slashes *$MATCH*"
 
-    # Regex escapes have to be double escaped for the awk commands to work in the matching step.
-    if [ "$MTYPE" == "X" ]; then
-        MATCH=`shellmock_escape_escapes $MATCH`
-    fi
-
-    MATCH_NORM=`eval shellmock_normalize_args \"$MATCH\"`
+    MATCH_NORM=`shellmock_normalize_args $MATCH`
     shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
     if [ "$FORWARD" != "" ]; then
         $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -38,6 +38,43 @@ skipIfNot()
     fi
 }
 
+#--------------------------------------------------------------
+# The arguments could have whitespace which we want to preserve
+# at times.  So we encapsulate all arguments with "
+#
+# Quotes in the matching process can cause issues.  This approach
+# would still have issues potentially if the arg separators are part of the input.
+#--------------------------------------------------------------
+shellmock_normalize_args2() {
+    shellmock_debug "shellmock_normalize_args: before *$**"
+    args=""
+    for arg in "$@"; do
+        args="$args$arg${SHELLMOCK_ARG_SEPARATOR}"
+    done
+    shellmock_debug "shellmock_normalize_args: after *$args*"
+    echo $args
+}
+
+shellmock_normalize_args() {
+    shellmock_debug "shellmock_normalize_args: before *$**"
+
+    local re="[[:space:]]+"
+    args=""
+    for arg in "${@}";do
+      if [[ $arg =~ $re ]]; then
+          shellmock_debug "shellmock_normalize_args: found space: $arg"
+          args="$args \"$arg\""
+          shellmock_debug "shellmock_normalize_args: args: $args"
+      else
+          args="$args $arg"
+      fi
+      shellmock_debug "shellmock_normalize_args: args: $args"
+    done
+    args=`echo $args|$AWK '{$1=$1;print}'`
+    shellmock_debug "shellmock_normalize_args: after *$args*"
+    echo $args
+
+}
 #---------------------------------------------------------------------
 # The variables are being pas$SED to sed and / are important to sed
 # so before we send to sed and write to the detour.properties we will
@@ -45,9 +82,19 @@ skipIfNot()
 #---------------------------------------------------------------------
 shellmock_escape_special_chars()
 {
+    shellmock_debug "shellmock_escape_special_chars: args: $*"
     $ECHO "$*" | $SED -e 's/\//\\\//g' -e 's/\[/\\\[/g' -e 's/\]/\\\]/g'
 }
-
+#---------------------------------------------------------------------
+# The variables are being pas$SED to sed and / are important to sed
+# so before we send to sed and write to the detour.properties we will
+# use sed to replace any / with \/ then the later sed will succede.
+#---------------------------------------------------------------------
+shellmock_escape_escapes()
+{
+    shellmock_debug "shellmock_escape_escapes: args: $*"
+    $ECHO "$*" | $SED -e 's/\\/\\\\/g'
+}
 #--------------------------------------------------------------------------------------------------------------------------------------
 # This funciton is used to mock bash scripts.  It maps inputs to outputs and if a given script is
 # expecting varying results then they are played back in the order the expects were given.
@@ -79,7 +126,11 @@ shellmock_escape_quotes()
 mock_capture_match()
 {
     local MATCH=$(shellmock_escape_quotes $1)
-    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK  'BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
+    local IN_MATCH=$(shellmock_escape_quotes $2)
+    shellmock_debug "mock_capture_match: cmd: *$cmd* MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
+    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
+    shellmock_debug "mock_capture_match: awk script: $AWK_SCRIPT"
+    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK "$AWK_SCRIPT"
 }
 
 #------------------------------------
@@ -88,7 +139,12 @@ mock_capture_match()
 mock_state_match()
 {
     local MATCH=$(shellmock_escape_quotes $1)
-    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK  'BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print $2; if ($3=="P" && index("'"$MATCH"'",$1)) print $2;if ($3=="X" && match("'"$MATCH"'", $1)) print $2}' | $TAIL -1)
+    local IN_MATCH=$(shellmock_escape_quotes $2)
+    shellmock_debug "mock_state_match: cmd: $cmd MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
+    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print $2; if ($3=="P" && index("'"$MATCH"'",$1)) print $2;if ($3=="X" && match("'"$MATCH"'", $1)) print $2}'
+    shellmock_debug "mock_state_match: awk cmd: $AWK_SCRIPT"
+    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK "$AWK_SCRIPT" | $TAIL -1)
+    shellmock_debug "mock_state_match: rec: *$rec*"
     $ECHO $rec
 }
 
@@ -108,16 +164,19 @@ shellmock_expect()
     local OUTPUT=""
     local STATUS=0
     local MTYPE="E"
+    local IN_MTYPE="E"
 
 
-    #------------------------------------------------
+    #--------------------------------------------------------------
     # read the switches so we know what to do
     # --exec -- forward to another command
-    # --match -- arg list to the base command
+    # -m,--match,--match-args -- arg list to the base command for matching
+    # -M,--match-stdin -- stdin contents for arg matching
     # --output -- standard out that should be echoed
     # --status -- exit status to return
-    # --type  -- exact or partial
-    #------------------------------------------------
+    # -t,--type,--args-match-type  -- exact or partial of arg list
+    # -T,--stdin-match-type -- exact or partial match of stdin
+    #--------------------------------------------------------------
     while [[ $# -gt 1 ]]
     do
         local key="$1"
@@ -130,7 +189,7 @@ shellmock_expect()
                 FORWARD="$2"
                 shift # past argument
                 ;;
-            -t|--type)
+            -t|--type|--args-match-type)
                if [ "$2" = "partial" ];then
                    MTYPE="P"
                elif [ "$2" = "exact" ]; then
@@ -143,8 +202,25 @@ shellmock_expect()
                fi
                 shift # past argument
                 ;;
-            -m|--match)
+            -T|--stdin-match-type)
+               if [ "$2" = "partial" ];then
+                   IN_MTYPE="P"
+               elif [ "$2" = "exact" ]; then
+                   IN_MTYPE="E"
+               elif [ "$2" = "regex" ]; then
+                   IN_MTYPE="X"
+               else
+                   shellmock_capture_err "mock_expect type $2 not valid should be exact or partial"
+                   return 1
+               fi
+                shift # past argument
+                ;;
+            -m|--match|--match-args)
                 MATCH="$2"
+                shift # past argument
+                ;;
+            -M|--match-stdin)
+                MATCH_IN="$2"
                 shift # past argument
                 ;;
             -o|--output)
@@ -178,8 +254,15 @@ shellmock_expect()
         $ECHO "#!/usr/bin/env bash" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO "export BATS_TEST_DIRNAME=\"$BATS_TEST_DIRNAME\"" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO ". shellmock" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-        $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'status=$?' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO 'if [ $status -ne 0 ]; then' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO '    shellmock_capture_err $0 failed ' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -194,15 +277,25 @@ shellmock_expect()
     #    forward implies executing an alternative command vs mocking
     #
     #---------------------------------------------------------------
-    if [ "$FORWARD" != "" ]; then
-        $ECHO "$MATCH@@FORWARD@@$FORWARD@@0@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
-    elif [ "$SOURCE" != "" ]; then
-        $ECHO "$MATCH@@SOURCE@@$SOURCE@@0@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
-    else
-        $ECHO "$MATCH@@OUTPUT@@$OUTPUT@@$STATUS@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    MATCH=`shellmock_escape_escapes $MATCH`
+    shellmock_debug "shellmock_expect: save slashes *$MATCH*"
+
+    # Regex escapes have to be double escaped for the awk commands to work in the matching step.
+    if [ "$MTYPE" == "X" ]; then
+        MATCH=`shellmock_escape_escapes $MATCH`
     fi
 
-    $ECHO "$MATCH@@1@@$MTYPE" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp"
+    MATCH_NORM=`eval shellmock_normalize_args \"$MATCH\"`
+    shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
+    if [ "$FORWARD" != "" ]; then
+        $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    elif [ "$SOURCE" != "" ]; then
+        $ECHO "$MATCH_NORM@@SOURCE@@$SOURCE@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    else
+        $ECHO "$MATCH_NORM@@OUTPUT@@$OUTPUT@@$STATUS@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
+    fi
+
+    $ECHO "$MATCH_NORM@@1@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp"
 
 }
 
@@ -213,8 +306,12 @@ shellmock_expect()
 #----------------------------------------
 shellmock_replay()
 {
-   cmd="$1"
-   match="$2"
+   local cmd="$1"
+   local match="$2"
+   local in_match="$3"
+
+   shellmock_debug "shellmock_replay: cmd: $cmd match: *$match* in_match: *$in_match*"
+
 
    local rec
    typeset -i rec
@@ -225,20 +322,22 @@ shellmock_replay()
    #-------------------------------------------------------------------------------------
    # Get the record index.  If there are multiple matches then they are returned in order
    #-------------------------------------------------------------------------------------
-   rec=$(mock_state_match "$match")
+   rec=$(mock_state_match "$match" "$in_match")
    if [ "$rec" = "0" ]; then
-       shellmock_capture_err "No record match found $cmd *$match*"
+       shellmock_capture_err "No record match found stdin:*$inmatch* cmd:$cmd args:*$match*"
        return 99
    fi
 
-   count=$(mock_capture_match "$match" | $WC -l)
-   entry=$(mock_capture_match "$match" | $HEAD -${rec} | $TAIL -1)
+   shellmock_debug "shellmock_replay: matched rec: $rec"
+   count=$(mock_capture_match "$match" "$in_match"| $WC -l)
+   entry=$(mock_capture_match "$match" "$in_match"| $HEAD -${rec} | $TAIL -1)
 
+   shellmock_debug "shellmock_replay: count: $count entry: $entry"
    #-------------------------------
    # If no entry is found then fail
    #-------------------------------
    if [ -z "$entry" ]; then
-       shellmock_capture_err "No match found for *$cmd* - *$match*"
+       shellmock_capture_err "No match found for stdin: *$in_match* cmd: *$cmd* - args: *$match*"
        exit 99
    fi
 
@@ -246,11 +345,19 @@ shellmock_replay()
    local output=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $3}')
    local status=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $4}')
    local mtype=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $5}')
+   local in_mtype=$($ECHO "$entry" | $AWK 'BEGIN{FS="@@"}{print $6}')
+
+   shellmock_debug "shellmock_replay: action: $action"
+   shellmock_debug "shellmock_replay: output: $output"
+   shellmock_debug "shellmock_replay: status: $status"
+   shellmock_debug "shellmock_replay: mtype: $mtype"
+   shellmock_debug "shellmock_replay: in_mtype: $in_mtype"
 
    #--------------------------------------------------------------------------------------
    # If there are multiple responses for a given match then keep track of a response index
    #--------------------------------------------------------------------------------------
    if [ "$count" -gt 1 ]; then
+       shellmock_debug "shelmock_replay: multiple matches: $count"
        $CP "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp" "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak"
        $CAT "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak" | $AWK 'BEGIN{FS="@@"}{ if (($3=="E" && $1=="'"$match"'")||($3=="P"&& index("'"$match"'",$1))||($3=="X" && match("'"$match"'",$1))) printf("%s@@%d@@%s\n",$1,$2+1,$3) ; else printf("%s@@%d@@%s\n",$1,$2,$3) }' > "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp"
    fi
@@ -259,6 +366,7 @@ shellmock_replay()
    # If this is a command forwarding request then call the command
    #--------------------------------------------------------------
    if [ "$action" = "SOURCE" ]; then
+       shellmock_debug "shellmock_replay: perform: SOURCE *. $output*"
        . $output
        return $?
 
@@ -271,7 +379,8 @@ shellmock_replay()
            tmpcmd=$($ECHO "$output" | $SED "s/{}/$tmpmatch/g")
        else
            tmpcmd=$output
-        fi
+       fi
+       shellmock_debug "shellmock_replay: perform: FORWARD *$tmpcmd*"
        $tmpcmd
        return $?
 
@@ -279,6 +388,7 @@ shellmock_replay()
    # Otherwise return the output
    #----------------------------
    else
+       shellmock_debug "shellmock_replay: perform: OUTPUT *$output* STATUS: $status"
        $ECHO "$output" | $AWK 'BEGIN{FS="%%"}{ for (i=1;i<=NF;i++) {print $i}}'
        return $status
    fi
@@ -289,8 +399,9 @@ shellmock_replay()
 #-------------------------------
 shellmock_capture_cmd()
 {
+    local cmd=`echo "$@" | awk '{$1=$1};1'`
     # trim leading and trailing spaces from the command
-    cmd=`echo "$*" | awk '{$1=$1};1'`
+    shellmock_debug "shellmock_capture_cmd: captured: *$cmd*"
     $ECHO "${cmd}" >> "$CAPTURE_FILE"
 }
 
@@ -400,7 +511,10 @@ if [ -z "$WC" ]; then
     export WC=`which wc`
 fi
 
-
+# Allow consumers to redefine the separator if necessary.
+if [ -z $SHELLMOCK_ARG_SEPARATOR ]; then
+    export SHELLMOCK_ARG_SEPARATOR="~~"
+fi
 
 export BATS_TEST_DIRNAME
 export CAPTURE_FILE=$BATS_TEST_DIRNAME/shellmock.out

--- a/sample-bats/sample.bats
+++ b/sample-bats/sample.bats
@@ -64,14 +64,12 @@ teardown()
 }
 
 #-----------------------------------------------------------------------------------
-# This test case demonstrates a normal bats test case where sample.sh is under test.
-# sample.sh will echo "sample found" based on the response to the grep command.
-# The default output will always be "sample found" because the script ensures
-# that grep will return 0.
+# This test case demonstrates mocking the grep command using the partial mock feature.
+# The sample.sh calls grep with two arguments.  The first argument is "sample line".
 #-----------------------------------------------------------------------------------
 @test "sample.sh-success-partial-mock" {
 
-    shellmock_expect grep --status 0 --output "Mocked output for Partial Match" --type partial --match '"sample line"'
+    shellmock_expect grep --status 0 --type partial --match '"sample line"'
 
     run ./sample.sh
 
@@ -86,6 +84,39 @@ teardown()
     [ "$output" = "sample found" ]
 
     shellmock_verify
+    [ "${#capture[@]}" = "1" ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+
+}
+
+#-----------------------------------------------------------------------------------
+# This test case demonstrates mocking the grep command using the partial mock feature.
+# The sample.sh calls grep with two arguments.  The first argument is "sample line".
+#
+# The only difference between this and the previous test is that the argument is passed
+# as single quotes 'sample line'.
+#
+# In that case you will notice that the command[] matches show as double quotes vs
+# single quotes. That is because the arguments are normalized to double quotes.
+#-----------------------------------------------------------------------------------
+@test "sample.sh-success-partial-mock-with-single-quotes" {
+
+    shellmock_expect grep --status 0 --type partial --match '"sample line"'
+
+    run ./sample.sh
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "1" ]
     [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }

--- a/sample-bats/sample.bats
+++ b/sample-bats/sample.bats
@@ -63,6 +63,33 @@ teardown()
 
 }
 
+#-----------------------------------------------------------------------------------
+# This test case demonstrates a normal bats test case where sample.sh is under test.
+# sample.sh will echo "sample found" based on the response to the grep command.
+# The default output will always be "sample found" because the script ensures
+# that grep will return 0.
+#-----------------------------------------------------------------------------------
+@test "sample.sh-success-partial-mock" {
+
+    shellmock_expect grep --status 0 --output "Mocked output for Partial Match" --type partial --match '"sample line"'
+
+    run ./sample.sh
+
+    shellmock_dump
+
+    [ "$status" = "0" ]
+
+    # Validate using lines array.
+    [ "${lines[0]}" = "sample found" ]
+
+    # Optionally since this is a single line you can use $output
+    [ "$output" = "sample found" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
+
+}
+
 #----------------------------------------------------------------------------------------
 # This test case demonstrates that the else condition if grep does not find the match.
 # By forcing the status of 1 grep will cause the "sample not found" message to be echoed.
@@ -84,6 +111,6 @@ teardown()
 
 
     shellmock_verify
-    [ "${capture[0]}" = 'grep-stub sample line sample.out' ]
+    [ "${capture[0]}" = 'grep-stub "sample line" sample.out' ]
 
 }

--- a/sample-bats/sample.sh
+++ b/sample-bats/sample.sh
@@ -21,7 +21,7 @@
 #     This is a sample script that we intend to test using the  mock framework.
 #
 #---------------------------------------------------------------------------------
-echo "sample line 1"  > sample.out
+echo "sample line"  > sample.out
 
 grep "sample line" sample.out > /dev/null
 if [ $? -ne 0 ]; then

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -66,7 +66,7 @@ teardown()
     [ "$output" = "mock a b failed" ]
 }
 
-@test "shellmock_expect multiple responses" {
+@test "shellmock_expect-multiple-responses" {
 
     skipIfNot multi-resources
 
@@ -120,7 +120,7 @@ teardown()
     run cp a c
     [ "$status" = "99" ]
 
-    grep 'No record match found cp \*a c\*' shellmock.err
+    grep 'No record match found stdin:\*\* cmd:cp args:\*a c\*' shellmock.err
 
 }
 
@@ -141,7 +141,7 @@ teardown()
 
     run cp b b
     [ "$status" = "99" ]
-    grep 'No record match found cp \*b b\*' shellmock.err
+    grep 'No record match found stdin:\*\* cmd:cp args:\*b b\*' shellmock.err
 
 }
 
@@ -310,13 +310,14 @@ teardown()
     skipIfNot regex-match
 
     shellmock_clean
-    shellmock_expect cp --status 0 --type regex --match "-a -s script\(\'t.*\)" --output "mock success"
+    shellmock_expect cp --status 0 --type regex --match "-a -s script\(\'t.*\'\)" --output "mock success"
 
     run cp -a -s "script('testit')"
     [ "$status" = "0" ]
     [ "$output" = "mock success" ]
 
     run cp -a -s "script('testit2')"
+
     [ "$status" = "0" ]
     [ "$output" = "mock success" ]
 

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -28,6 +28,7 @@ setup()
 {
     # For testing setup the path so that install is not required.
     export PATH=../bin:$PATH
+    unset SHELLMOCK_V1_COMPATIBILITY
     . shellmock
 
 }
@@ -485,3 +486,19 @@ teardown()
 
 }
 
+@test "shellmock_expect quotes compatibility test" {
+
+    skipIfNot quotes-compatibility-v1.0-test
+
+    export SHELLMOCK_V1_COMPATIBILITY="enabled"
+
+    shellmock_clean
+    shellmock_expect cp --status 0 --match "a b c" --output "mock a b success"
+
+    run cp "a b" c
+    [ "$status" = "0" ]
+    [ "$output" = "mock a b success" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = "cp-stub a b c" ]
+}

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -106,6 +106,24 @@ teardown()
 
 }
 
+@test "shellmock_expect --status 0 partial-match with double quotes" {
+
+    skipIfNot partial-match
+
+    shellmock_clean
+    shellmock_expect cp --status 0 --type partial --match '"a file.c"' --output "mock success"
+
+    run cp "a file.c" b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run cp "a file.c" c
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+}
+
+
 @test "shellmock_expect failed matches" {
 
     skipIfNot failed-matches


### PR DESCRIPTION
Resolves issue #14 and Resolves issue #25 

- Added logic to normalize arguments by looking for white space and recreating the match arguments with those arguments with spaces into one quoted argument.
Added additional test cases and examples
- This change does have a compatibility change from previous implementation.

If a test case has input '"a b" c' today then previously the capture[0] = "a b c" would not be capture[0] = '"a b" c'.

Like wise if the old match logic was --match "a b c" and the stub was called with "a b" c then the match logic will no longer work with the new approach.