### PR TITLE
Resolves issue #24 - Add support for stdin matching.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -215,13 +215,18 @@ behavior that you provide.
 |===
 |**Item**|**Description**|**Required?**
 |cmd|unix command to mock|Yes.
-|--type|Type of match **partial** or **exact**|No. Defaults to **exact**
-|--match|Arguments passed to cmd that indicate a match to mock.|Yes.
-|--exec|Command string to execute for custom behavior.|No.
-|--source|Command string to source.|No.
+|-t,--type|Type of argument list matching: **partial**, **exact** **regex**|No. Defaults to **exact**
+|-T,--stdin-match-type|Type of stdin matching: **partial**, **exact**, or **regex** | **exact**
+|-m,--match,--match-args|Arguments passed to cmd that indicate a match to mock.|No.
+|-M,--match-stdin|stdin data that is expected to be considered a match.|No.
+|-e,--exec|Command string to execute for custom behavior.|No.
+|-S,--source|Command string to source.|No.
 |--output|Text string to echo if there is a match.|No.
 |--status|status code to return|No. Defaults to 0
 |===
+
+Matching can be defined based on the argument list or the stdin data stream.  When both **--match** and **--match-stdin** are provided in an expectation then
+it becomes an AND of the two conditions.
 
 **shellmock_expect** supports returning a single or multiple responses for a given match criteria.  The responses will be returned in the order defined.  Once all response are seen the last response will be returned indefinitely.
 

--- a/bin/shellmock
+++ b/bin/shellmock
@@ -120,9 +120,14 @@ mock_capture_match()
     local MATCH=$(shellmock_escape_quotes $1)
     local IN_MATCH=$(shellmock_escape_quotes $2)
     shellmock_debug "mock_capture_match: cmd: *$cmd* MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
-    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
-    shellmock_debug "mock_capture_match: awk script: $AWK_SCRIPT"
-    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK "$AWK_SCRIPT"
+
+    local AWK_ARG_SCRIPT='BEGIN{FS="@@"}{if ($5=="E" && ($1 == "'"$MATCH"'")) print; if ($5=="P" && index("'"$MATCH"'",$1)) print; if ($5=="X" && match("'"$MATCH"'", $1)) print}'
+    shellmock_debug "mock_capture_match: awk arg matcher script: $AWK_ARG_SCRIPT"
+
+    local AWK_STDIN_SCRIPT='BEGIN{FS="@@"}{if ($6=="E" && ($7 == "'"$IN_MATCH"'")) print; if ($6=="P" && index("'"$IN_MATCH"'",$7)) print; if ($6=="X" && match("'"$IN_MATCH"'", $7)) print}'
+    shellmock_debug "mock_capture_match: awk stdin matcher script: $AWK_STDIN_SCRIPT"
+
+    $CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp" | $AWK "$AWK_ARG_SCRIPT" | $AWK "$AWK_STDIN_SCRIPT"
 }
 
 #------------------------------------
@@ -133,9 +138,13 @@ mock_state_match()
     local MATCH=$(shellmock_escape_quotes $1)
     local IN_MATCH=$(shellmock_escape_quotes $2)
     shellmock_debug "mock_state_match: cmd: $cmd MATCH: *$MATCH* IN_MATCH: *$IN_MATCH*"
-    local AWK_SCRIPT='BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print $2; if ($3=="P" && index("'"$MATCH"'",$1)) print $2;if ($3=="X" && match("'"$MATCH"'", $1)) print $2}'
-    shellmock_debug "mock_state_match: awk cmd: $AWK_SCRIPT"
-    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK "$AWK_SCRIPT" | $TAIL -1)
+    local AWK_ARG_SCRIPT='BEGIN{FS="@@"}{if ($3=="E" && ($1 == "'"$MATCH"'")) print; if ($3=="P" && index("'"$MATCH"'",$1)) print;if ($3=="X" && match("'"$MATCH"'", $1)) print}'
+    shellmock_debug "mock_state_match: awk arg match cmd: $AWK_ARG_SCRIPT"
+
+    local AWK_STDIN_SCRIPT='BEGIN{FS="@@"}{if ($4=="E" && ($5 == "'"$IN_MATCH"'")) print $2; if ($4=="P" && index("'"$IN_MATCH"'",$5)) print $2;if ($4=="X" && match("'"$IN_MATCH"'", $5)) print $2}'
+    shellmock_debug "mock_state_match: awk stdin match cmd: $AWK_STDIN_SCRIPT"
+
+    local rec=$($CAT "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp" | $AWK "$AWK_ARG_SCRIPT" | $AWK "$AWK_STDIN_SCRIPT" | $TAIL -1)
     shellmock_debug "mock_state_match: rec: *$rec*"
     $ECHO $rec
 }
@@ -235,6 +244,13 @@ shellmock_expect()
         shift # past argument or value
     done
 
+    shellmock_debug "shellmock_expect: FORWARD=$FORWARD"
+    shellmock_debug "shellmock_expect: MATCH=$MATCH"
+    shellmock_debug "shellmock_expect: OUTPUT=$OUTPUT"
+    shellmock_debug "shellmock_expect: STATUS=$STATUS"
+    shellmock_debug "shellmock_expect: MTYPE=$MTYPE"
+    shellmock_debug "shellmock_expect: MATCH_IN=$MATCH_IN"
+    shellmock_debug "shellmock_expect: IN_MTYPE=$IN_MTYPE"
 
     #-----------------------------------------------------------
     # If the command has not been stubbed then generate the stub
@@ -246,16 +262,21 @@ shellmock_expect()
         $ECHO "#!/usr/bin/env bash" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO "export BATS_TEST_DIRNAME=\"$BATS_TEST_DIRNAME\"" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         $ECHO ". shellmock" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "          stdin[$cnt]=$line" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "          let cnt=$cnt+1" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "      done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-#        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO 'shellmock_debug shellmock_stub: $0-stub: args: "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "if [ -p /dev/stdin ]; then" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    let cnt=0" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "    while IFS= read line; do" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO '          stdin[$cnt]=$line' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO '          let cnt=$cnt+1' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "     done" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO '     if [ $cnt -gt 0 ]; then stdin[$cnt]=" | "; fi' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO 'else' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO '    shellmock_debug shellmock_stub: $0-stub: no stdin' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO "fi" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+        $ECHO 'shellmock_debug shellmock_stub: $0-stub: stdin: "${stdin[@]}"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         if [ -z $SHELLMOCK_V1_COMPATIBILITY ]; then
-             $ECHO 'shellmock_capture_cmd '${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
-             $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO 'shellmock_capture_cmd "${stdin[@]}"'${cmd}'-stub "`shellmock_normalize_args "$@"`"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
+             $ECHO "shellmock_replay $cmd "'"`shellmock_normalize_args "$@"`" "${stdin[@]}"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
         else
              $ECHO 'shellmock_capture_cmd '${cmd}'-stub "$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
              $ECHO "shellmock_replay $cmd "'"$*"' >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd"
@@ -280,6 +301,15 @@ shellmock_expect()
         MATCH_NORM=$MATCH
     fi
 
+    # Field definitions for the capture file
+    # $1 - arg match criteria
+    # $2 - type of expectation (forward, source, or output)
+    # $3 - data related to the expectation type: script to foward to, the script to source, or the output to display
+    # $4 - status value to return
+    # $5 - type of argument matcher
+    # $6 - type of stdin matcher
+    # $7 - stdin match criteria
+
     shellmock_debug "shellmock_expect: normalized arg match string *$MATCH* as *$MATCH_NORM*"
     if [ "$FORWARD" != "" ]; then
         $ECHO "$MATCH_NORM@@FORWARD@@$FORWARD@@0@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
@@ -289,6 +319,12 @@ shellmock_expect()
         $ECHO "$MATCH_NORM@@OUTPUT@@$OUTPUT@@$STATUS@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.capture.tmp"
     fi
 
+    # Field definitions for the state file:
+    # $1 - argument match criteria
+    # $2 - which occurrence is the active when there are multiple responses to playback
+    # $3 - argument match type
+    # $4 - stdin match type
+    # $5 - stdin match criteria
     $ECHO "$MATCH_NORM@@1@@$MTYPE@@$IN_MTYPE@@$MATCH_IN" >> "$BATS_TEST_DIRNAME/tmpstubs/$cmd.playback.state.tmp"
 
 }
@@ -318,7 +354,7 @@ shellmock_replay()
    #-------------------------------------------------------------------------------------
    rec=$(mock_state_match "$match" "$in_match")
    if [ "$rec" = "0" ]; then
-       shellmock_capture_err "No record match found stdin:*$inmatch* cmd:$cmd args:*$match*"
+       shellmock_capture_err "No record match found stdin:*$in_match* cmd:$cmd args:*$match*"
        return 99
    fi
 
@@ -353,7 +389,8 @@ shellmock_replay()
    if [ "$count" -gt 1 ]; then
        shellmock_debug "shelmock_replay: multiple matches: $count"
        $CP "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp" "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak"
-       $CAT "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak" | $AWK 'BEGIN{FS="@@"}{ if (($3=="E" && $1=="'"$match"'")||($3=="P"&& index("'"$match"'",$1))||($3=="X" && match("'"$match"'",$1))) printf("%s@@%d@@%s\n",$1,$2+1,$3) ; else printf("%s@@%d@@%s\n",$1,$2,$3) }' > "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp"
+       # This script updates index for the next mock when there is more than one response value.
+       $CAT "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.bak" | $AWK 'BEGIN{FS="@@"}{ if ((($3=="E" && $1=="'"$match"'")||($3=="P"&& index("'"$match"'",$1))||($3=="X" && match("'"$match"'",$1))) && (($4=="E" && $5=="'"$in_match"'")||($4=="P"&& index("'"$in_match"'",$5))||($4=="X" && match("'"$in_match"'",$5)))) printf("%s@@%d@@%s@@%s@@%s\n",$1,$2+1,$3,$4,$5) ; else printf("%s@@%d@@%s@@%s@@%s\n",$1,$2,$3,$4,$5) }' > "$BATS_TEST_DIRNAME/tmpstubs/$1.playback.state.tmp"
    fi
 
    #--------------------------------------------------------------
@@ -377,7 +414,7 @@ shellmock_replay()
            tmpcmd=$output
        fi
        shellmock_debug "shellmock_replay: perform: FORWARD *$tmpcmd*"
-       $tmpcmd
+       eval $tmpcmd
        return $?
 
    #----------------------------
@@ -430,7 +467,7 @@ shellmock_dump()
 shellmock_debug()
 {
     if [ ! -z "$TEST_FUNCTION" ]; then
-        POSIXLY_CORRECT=1 $ECHO "$1" >> "$shellmock_capture_debug"
+        POSIXLY_CORRECT=1 $ECHO "$@" >> "$shellmock_capture_debug"
     fi
 }
 

--- a/test/shellmock.bats
+++ b/test/shellmock.bats
@@ -502,3 +502,169 @@ teardown()
     shellmock_verify
     [ "${capture[0]}" = "cp-stub a b c" ]
 }
+
+@test "shellmock_expect --status 0 with stdin" {
+
+    skipIfNot status-0-stdin
+
+    shellmock_clean
+
+    #---------------------------------------------------------------
+    # Had issues getting the run echo "a b" | cat to work so
+    # I used the exec feature to create stubs to invoke the cat-stub
+    #---------------------------------------------------------------
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat'
+    shellmock_expect helper --status 0 --match "a c" --exec 'echo a c | cat'
+
+    shellmock_expect cat --status 0 --match-stdin "a b" --output "mock success"
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run helper a c
+    [ "$status" = "99" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "4" ]
+    [ "${capture[0]}" = 'helper-stub a b' ]
+    [ "${capture[1]}" = 'a b | cat-stub' ]
+    [ "${capture[2]}" = 'helper-stub a c' ]
+    [ "${capture[3]}" = 'a c | cat-stub' ]
+
+}
+
+@test "shellmock_expect --status 0 with stdin and args" {
+
+    skipIfNot status-0-stdin-and-args
+
+    shellmock_clean
+
+    #---------------------------------------------------------------
+    # Had issues getting the run echo "a b" | cat to work so
+    # I used the exec feature to create stubs to invoke the cat-stub
+    #---------------------------------------------------------------
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat -t -v'
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat -p -q'
+
+    shellmock_expect cat --status 0 --match-args "-t -v" --match-stdin "a b" --output "mock success"
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run helper a b
+    [ "$status" = "99" ]
+
+
+    shellmock_verify
+    [ "${#capture[@]}" = "4" ]
+    [ "${capture[0]}" = 'helper-stub a b' ]
+    [ "${capture[1]}" = 'a b | cat-stub -t -v' ]
+    [ "${capture[2]}" = 'helper-stub a b' ]
+    [ "${capture[3]}" = 'a b | cat-stub -p -q' ]
+
+}
+
+@test "shellmock_expect --status 0 with stdin and args multi-response" {
+
+    skipIfNot status-0-stdin-and-args-multi
+
+    shellmock_clean
+
+    #---------------------------------------------------------------
+    # Had issues getting the run echo "a b" | cat to work so
+    # I used the exec feature to create stubs to invoke the cat-stub
+    #---------------------------------------------------------------
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat -t -v'
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat -p -q'
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat -t -v'
+
+    shellmock_expect cat --status 0 --match-args "-t -v" --match-stdin "a b" --output "mock success 1"
+    shellmock_expect cat --status 0 --match-args "-t -v" --match-stdin "a b" --output "mock success 2"
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success 1" ]
+
+    run helper a b
+    [ "$status" = "99" ]
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success 2" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "6" ]
+    [ "${capture[0]}" = 'helper-stub a b' ]
+    [ "${capture[1]}" = 'a b | cat-stub -t -v' ]
+    [ "${capture[2]}" = 'helper-stub a b' ]
+    [ "${capture[3]}" = 'a b | cat-stub -p -q' ]
+    [ "${capture[4]}" = 'helper-stub a b' ]
+    [ "${capture[5]}" = 'a b | cat-stub -t -v' ]
+
+}
+
+@test "shellmock_expect --status 0 with stdin and regex" {
+
+    skipIfNot status-0-stdin-regex
+
+    shellmock_clean
+
+    #---------------------------------------------------------------
+    # Had issues getting the run echo "a b" | cat to work so
+    # I used the exec feature to create stubs to invoke the cat-stub
+    #---------------------------------------------------------------
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat'
+    shellmock_expect helper --status 0 --match "a c" --exec 'echo a c | cat'
+
+    shellmock_expect cat --status 0 --stdin-match-type regex --match-stdin "a.*" --output "mock success"
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run helper a c
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "4" ]
+    [ "${capture[0]}" = 'helper-stub a b' ]
+    [ "${capture[1]}" = 'a b | cat-stub' ]
+    [ "${capture[2]}" = 'helper-stub a c' ]
+    [ "${capture[3]}" = 'a c | cat-stub' ]
+
+}
+
+@test "shellmock_expect --status 0 with stdin partial match" {
+
+    skipIfNot status-0-stdin-partial
+
+    shellmock_clean
+
+    #---------------------------------------------------------------
+    # Had issues getting the run echo "a b" | cat to work so
+    # I used the exec feature to create stubs to invoke the cat-stub
+    #---------------------------------------------------------------
+    shellmock_expect helper --status 0 --match "a b" --exec 'echo a b | cat'
+    shellmock_expect helper --status 0 --match "a c" --exec 'echo a c | cat'
+
+    shellmock_expect cat --status 0 --stdin-match-type regex --match-stdin "a" --output "mock success"
+
+    run helper a b
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    run helper a c
+    [ "$status" = "0" ]
+    [ "$output" = "mock success" ]
+
+    shellmock_verify
+    [ "${#capture[@]}" = "4" ]
+    [ "${capture[0]}" = 'helper-stub a b' ]
+    [ "${capture[1]}" = 'a b | cat-stub' ]
+    [ "${capture[2]}" = 'helper-stub a c' ]
+    [ "${capture[3]}" = 'a c | cat-stub' ]
+
+}


### PR DESCRIPTION
Add feature for --match-stdin and --stdin-match-type arguments to allow testers to mock and match functions based on stdin as well as the argument list.